### PR TITLE
Refactor Sed

### DIFF
--- a/editors/sed.rs
+++ b/editors/sed.rs
@@ -119,50 +119,86 @@ extern "C" {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct globals {
+  // options
   pub be_quiet: libc::c_int,
   pub regex_type: libc::c_int,
+
   pub nonstdout: *mut FILE,
   pub outname: *mut libc::c_char,
   pub hold_space: *mut libc::c_char,
   pub exitcode: smallint,
+
+  /// list of input files
   pub current_input_file: libc::c_int,
   pub last_input_file: libc::c_int,
   pub input_file_list: *mut *mut libc::c_char,
   pub current_fp: *mut FILE,
+
   pub regmatch: [regmatch_t; 10],
   pub previous_regex_ptr: *mut regex_t,
+
+  /// linked list of sed commands
   pub sed_cmd_head: *mut sed_cmd_t,
   pub sed_cmd_tail: *mut *mut sed_cmd_t,
+
+  /// linked list of append lines
   pub append_head: *mut llist_t,
+
   pub add_cmd_line: *mut libc::c_char,
   pub pipeline: pipeline,
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct pipeline {
+  /// Space to hold string
   pub buf: *mut libc::c_char,
+  /// Space used
   pub idx: libc::c_int,
+  /// Space allocated
   pub len: libc::c_int,
 }
 #[derive(Copy, Clone, BitfieldStruct)]
 #[repr(C)]
+/// Each sed command turns into one of these structures.
 pub struct sed_cmd_t {
+  /// Next command (linked list, NULL terminated)
   pub next: *mut sed_cmd_t,
+
+  // address storage
+  /// sed -e '/match/cmd'
   pub beg_match: *mut regex_t,
+  /// sed -e '/match/,/end_match/cmd'
   pub end_match: *mut regex_t,
+  /// For 's/sub_match/string/'
   pub sub_match: *mut regex_t,
+  /// 'sed 1p'   0 == apply commands to all lines
   pub beg_line: libc::c_int,
+  /// copy of the above, needed for -i
   pub beg_line_orig: libc::c_int,
+  /// 'sed 1,3p' 0 == one line only. -1 = last line ($). -2-N = +N
   pub end_line: libc::c_int,
   pub end_line_orig: libc::c_int,
+  /// File (sw) command writes to, NULL for none.
   pub sw_file: *mut FILE,
+  /// Data string for (saicytb) commands.
   pub string: *mut libc::c_char,
+  /// (s) Which match to replace (0 for all)
   pub which_match: libc::c_uint,
+
+  // Bitfields (gcc won't group them if we don't)
+  /// the '!' after the address
   #[bitfield(name = "invert", ty = "libc::c_uint", bits = "0..=0")]
+  /// Next line also included in match?
   #[bitfield(name = "in_match", ty = "libc::c_uint", bits = "1..=1")]
+  /// (s) print option
   #[bitfield(name = "sub_p", ty = "libc::c_uint", bits = "2..=2")]
   pub invert_in_match_sub_p: [u8; 1],
+  /// Last line written by (sw) had no '\n'
   pub sw_last_char: libc::c_char,
+
+  // GENERAL FIELDS
+  /// The current command char
   pub cmd: libc::c_char,
 }
 

--- a/editors/sed.rs
+++ b/editors/sed.rs
@@ -333,7 +333,7 @@ unsafe fn parse_escapes(
     d = d.offset(1)
   }
   *d = '\u{0}' as i32 as libc::c_char;
-  return d.wrapping_offset_from(dest) as libc::c_long as libc::c_uint;
+  d.wrapping_offset_from(dest) as libc::c_long as libc::c_uint
 }
 
 unsafe fn copy_parsing_escapes(
@@ -350,7 +350,7 @@ unsafe fn copy_parsing_escapes(
     string = dest;
     s = s.offset(2)
   }
-  return dest;
+  dest
 }
 
 /// walks left to right through a string beginning at a specified index and
@@ -426,8 +426,7 @@ unsafe fn parse_regex_delim(
   cmdstr_ptr = cmdstr_ptr.offset((idx + 1i32) as isize);
   idx = index_of_next_unescaped_regexp_delim(-(delimiter as libc::c_int), cmdstr_ptr);
   *replace = copy_parsing_escapes(cmdstr_ptr, idx);
-  return (cmdstr_ptr.wrapping_offset_from(cmdstr) as libc::c_long + idx as libc::c_long)
-    as libc::c_int;
+  (cmdstr_ptr.wrapping_offset_from(cmdstr) as libc::c_long + idx as libc::c_long) as libc::c_int
 }
 
 /// returns the index in the string just past where the address ends.
@@ -481,7 +480,7 @@ unsafe fn get_address(
     /* Move position to next character after last delimiter */
     pos = pos.offset((next + 1i32) as isize)
   }
-  return pos.wrapping_offset_from(my_str) as libc::c_long as libc::c_int;
+  pos.wrapping_offset_from(my_str) as libc::c_long as libc::c_int
 }
 
 /// Grab a filename.  Whitespace at start is skipped, then goes to EOL.
@@ -509,7 +508,7 @@ unsafe fn parse_file_cmd(
     /* eol is NUL */
     *retval = xstrdup(start)
   }
-  return eol.wrapping_offset_from(filecmdstr) as libc::c_long as libc::c_int;
+  eol.wrapping_offset_from(filecmdstr) as libc::c_long as libc::c_int
 }
 
 unsafe fn parse_subst_cmd(
@@ -614,7 +613,7 @@ unsafe fn parse_subst_cmd(
     xregcomp((*sed_cmd).sub_match, match_0, cflags);
   }
   free(match_0 as *mut libc::c_void);
-  return idx;
+  idx
 }
 
 /// Process the commands arguments
@@ -746,7 +745,7 @@ unsafe fn parse_cmd_args(
     );
   }
   /* give back whatever's left over */
-  return cmdstr;
+  cmdstr
 }
 
 /// Parse address+command sets, skipping comment lines.
@@ -1120,7 +1119,7 @@ unsafe fn do_subst_command(
   *line_p = (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
     .pipeline
     .buf;
-  return altered as libc::c_int;
+  altered as libc::c_int
 }
 
 /// Set command pointer to point to this label.  (Does not handle null label.)
@@ -1301,7 +1300,7 @@ unsafe fn get_next_line(
     *fresh23 += 1
   }
   *gets_char = gc;
-  return temp;
+  temp
 }
 
 unsafe fn beg_match(
@@ -1320,7 +1319,7 @@ unsafe fn beg_match(
     let ref mut fresh24 = (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).previous_regex_ptr;
     *fresh24 = (*sed_cmd).beg_match
   }
-  return retval;
+  retval
 }
 
 /// Process all the lines in all the files
@@ -9241,5 +9240,5 @@ pub unsafe extern "C" fn sed_main(
     }
   }
   process_files();
-  return (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).exitcode as libc::c_int;
+  (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).exitcode as libc::c_int
 }

--- a/editors/sed.rs
+++ b/editors/sed.rs
@@ -279,7 +279,7 @@ pub const NO_EOL_CHAR: C2RustUnnamed_2 = 1;
 
 static semicolon_whitespace: [libc::c_char; 7] = [59, 32, 10, 13, 9, 11, 0];
 
-/* If something bad happens during -i operation, delete temp file */
+/// If something bad happens during -i operation, delete temp file
 unsafe extern "C" fn cleanup_outname() {
   if !(*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
     .outname
@@ -288,8 +288,9 @@ unsafe extern "C" fn cleanup_outname() {
     unlink((*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).outname);
   };
 }
-/* strcpy, replacing "\from" with 'to'. If to is NUL, replacing "\any" with 'any' */
-unsafe extern "C" fn parse_escapes(
+
+/// strcpy, replacing "\from" with 'to'. If to is NUL, replacing "\any" with 'any'
+unsafe fn parse_escapes(
   mut dest: *mut libc::c_char,
   mut string: *const libc::c_char,
   mut len: libc::c_int,
@@ -334,7 +335,8 @@ unsafe extern "C" fn parse_escapes(
   *d = '\u{0}' as i32 as libc::c_char;
   return d.wrapping_offset_from(dest) as libc::c_long as libc::c_uint;
 }
-unsafe extern "C" fn copy_parsing_escapes(
+
+unsafe fn copy_parsing_escapes(
   mut string: *const libc::c_char,
   mut len: libc::c_int,
 ) -> *mut libc::c_char {
@@ -350,13 +352,12 @@ unsafe extern "C" fn copy_parsing_escapes(
   }
   return dest;
 }
-/*
- * index_of_next_unescaped_regexp_delim - walks left to right through a string
- * beginning at a specified index and returns the index of the next regular
- * expression delimiter (typically a forward slash ('/')) not preceded by
- * a backslash ('\').  A negative delimiter disables square bracket checking.
- */
-unsafe extern "C" fn index_of_next_unescaped_regexp_delim(
+
+/// walks left to right through a string beginning at a specified index and
+/// returns the index of the next regular expression delimiter (typically a
+/// forward slash ('/')) not preceded by a backslash ('\').  A negative
+/// delimiter disables square bracket checking.
+unsafe fn index_of_next_unescaped_regexp_delim(
   mut delimiter: libc::c_int,
   mut str: *const libc::c_char,
 ) -> libc::c_int {
@@ -398,10 +399,9 @@ unsafe extern "C" fn index_of_next_unescaped_regexp_delim(
     delimiter,
   );
 }
-/*
- *  Returns the index of the third delimiter
- */
-unsafe extern "C" fn parse_regex_delim(
+
+/// Returns the index of the third delimiter
+unsafe fn parse_regex_delim(
   mut cmdstr: *const libc::c_char,
   mut match_0: *mut *mut libc::c_char,
   mut replace: *mut *mut libc::c_char,
@@ -429,10 +429,9 @@ unsafe extern "C" fn parse_regex_delim(
   return (cmdstr_ptr.wrapping_offset_from(cmdstr) as libc::c_long + idx as libc::c_long)
     as libc::c_int;
 }
-/*
- * returns the index in the string just past where the address ends.
- */
-unsafe extern "C" fn get_address(
+
+/// returns the index in the string just past where the address ends.
+unsafe fn get_address(
   mut my_str: *const libc::c_char,
   mut linenum: *mut libc::c_int,
   mut regex: *mut *mut regex_t,
@@ -484,8 +483,9 @@ unsafe extern "C" fn get_address(
   }
   return pos.wrapping_offset_from(my_str) as libc::c_long as libc::c_int;
 }
-/* Grab a filename.  Whitespace at start is skipped, then goes to EOL. */
-unsafe extern "C" fn parse_file_cmd(
+
+/// Grab a filename.  Whitespace at start is skipped, then goes to EOL.
+unsafe fn parse_file_cmd(
   mut filecmdstr: *const libc::c_char,
   mut retval: *mut *mut libc::c_char,
 ) -> libc::c_int {
@@ -511,7 +511,8 @@ unsafe extern "C" fn parse_file_cmd(
   }
   return eol.wrapping_offset_from(filecmdstr) as libc::c_long as libc::c_int;
 }
-unsafe extern "C" fn parse_subst_cmd(
+
+unsafe fn parse_subst_cmd(
   mut sed_cmd: *mut sed_cmd_t,
   mut substr: *const libc::c_char,
 ) -> libc::c_int {
@@ -615,10 +616,9 @@ unsafe extern "C" fn parse_subst_cmd(
   free(match_0 as *mut libc::c_void);
   return idx;
 }
-/*
- *  Process the commands arguments
- */
-unsafe extern "C" fn parse_cmd_args(
+
+/// Process the commands arguments
+unsafe fn parse_cmd_args(
   mut sed_cmd: *mut sed_cmd_t,
   mut cmdstr: *const libc::c_char,
 ) -> *const libc::c_char {
@@ -748,8 +748,9 @@ unsafe extern "C" fn parse_cmd_args(
   /* give back whatever's left over */
   return cmdstr;
 }
-/* Parse address+command sets, skipping comment lines. */
-unsafe extern "C" fn add_cmd(mut cmdstr: *const libc::c_char) {
+
+/// Parse address+command sets, skipping comment lines.
+unsafe fn add_cmd(mut cmdstr: *const libc::c_char) {
   let mut sed_cmd: *mut sed_cmd_t = 0 as *mut sed_cmd_t;
   let mut len: libc::c_uint = 0;
   let mut n: libc::c_uint = 0;
@@ -890,7 +891,8 @@ unsafe extern "C" fn add_cmd(mut cmdstr: *const libc::c_char) {
   let ref mut fresh10 = (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).add_cmd_line;
   *fresh10 = 0 as *mut libc::c_char;
 }
-unsafe extern "C" fn pipe_putc(mut c: libc::c_char) {
+
+unsafe fn pipe_putc(mut c: libc::c_char) {
   if (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
     .pipeline
     .idx
@@ -924,10 +926,8 @@ unsafe extern "C" fn pipe_putc(mut c: libc::c_char) {
     .buf
     .offset(fresh13 as isize) = c;
 }
-unsafe extern "C" fn do_subst_w_backrefs(
-  mut line: *mut libc::c_char,
-  mut replace: *mut libc::c_char,
-) {
+
+unsafe fn do_subst_w_backrefs(mut line: *mut libc::c_char, mut replace: *mut libc::c_char) {
   let mut i: libc::c_int = 0;
   let mut j: libc::c_int = 0;
   /* go through the replacement string */
@@ -974,7 +974,8 @@ unsafe extern "C" fn do_subst_w_backrefs(
     i += 1
   }
 }
-unsafe extern "C" fn do_subst_command(
+
+unsafe fn do_subst_command(
   mut sed_cmd: *mut sed_cmd_t,
   mut line_p: *mut *mut libc::c_char,
 ) -> libc::c_int {
@@ -1121,8 +1122,9 @@ unsafe extern "C" fn do_subst_command(
     .buf;
   return altered as libc::c_int;
 }
-/* Set command pointer to point to this label.  (Does not handle null label.) */
-unsafe extern "C" fn branch_to(mut label: *mut libc::c_char) -> *mut sed_cmd_t {
+
+/// Set command pointer to point to this label.  (Does not handle null label.)
+unsafe fn branch_to(mut label: *mut libc::c_char) -> *mut sed_cmd_t {
   let mut sed_cmd: *mut sed_cmd_t = 0 as *mut sed_cmd_t;
   sed_cmd = (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).sed_cmd_head;
   while !sed_cmd.is_null() {
@@ -1139,13 +1141,15 @@ unsafe extern "C" fn branch_to(mut label: *mut libc::c_char) -> *mut sed_cmd_t {
     label,
   );
 }
-unsafe extern "C" fn append(mut s: *mut libc::c_char) {
+
+unsafe fn append(mut s: *mut libc::c_char) {
   llist_add_to_end(
     &mut (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).append_head,
     s as *mut libc::c_void,
   );
 }
-unsafe extern "C" fn puts_maybe_newline(
+
+unsafe fn puts_maybe_newline(
   mut s: *mut libc::c_char,
   mut file: *mut FILE,
   mut last_puts_char: *mut libc::c_char,
@@ -1179,7 +1183,8 @@ unsafe extern "C" fn puts_maybe_newline(
   }
   *last_puts_char = lpc;
 }
-unsafe extern "C" fn flush_append(mut last_puts_char: *mut libc::c_char) {
+
+unsafe fn flush_append(mut last_puts_char: *mut libc::c_char) {
   let mut data: *mut libc::c_char = 0 as *mut libc::c_char;
   loop
   /* Output appended lines. */
@@ -1207,10 +1212,10 @@ unsafe extern "C" fn flush_append(mut last_puts_char: *mut libc::c_char) {
     free(data as *mut libc::c_void);
   }
 }
-/* Get next line of input from G.input_file_list, flushing append buffer and
- * noting if we ran out of files without a newline on the last line we read.
- */
-unsafe extern "C" fn get_next_line(
+
+/// Get next line of input from G.input_file_list, flushing append buffer and
+/// noting if we ran out of files without a newline on the last line we read.
+unsafe fn get_next_line(
   mut gets_char: *mut libc::c_char,
   mut last_puts_char: *mut libc::c_char,
 ) -> *mut libc::c_char {
@@ -1298,7 +1303,8 @@ unsafe extern "C" fn get_next_line(
   *gets_char = gc;
   return temp;
 }
-unsafe extern "C" fn beg_match(
+
+unsafe fn beg_match(
   mut sed_cmd: *mut sed_cmd_t,
   mut pattern_space: *const libc::c_char,
 ) -> libc::c_int {
@@ -1316,8 +1322,9 @@ unsafe extern "C" fn beg_match(
   }
   return retval;
 }
-/* Process all the lines in all the files */
-unsafe extern "C" fn process_files() {
+
+/// Process all the lines in all the files
+unsafe fn process_files() {
   let mut current_block: u64;
   let mut pattern_space: *mut libc::c_char = 0 as *mut libc::c_char;
   let mut next_line: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -9032,12 +9039,12 @@ unsafe extern "C" fn process_files() {
     free(pattern_space as *mut libc::c_void);
   }
 }
-/* It is possible to have a command line argument with embedded
- * newlines.  This counts as multiple command lines.
- * However, newline can be escaped: 's/e/z\<newline>z/'
- * add_cmd() handles this.
- */
-unsafe extern "C" fn add_cmd_block(mut cmdstr: *mut libc::c_char) {
+
+/// It is possible to have a command line argument with embedded
+/// newlines.  This counts as multiple command lines.
+/// However, newline can be escaped: 's/e/z\<newline>z/'
+/// add_cmd() handles this.
+unsafe fn add_cmd_block(mut cmdstr: *mut libc::c_char) {
   let mut sv: *mut libc::c_char = 0 as *mut libc::c_char;
   let mut eol: *mut libc::c_char = 0 as *mut libc::c_char;
   sv = xstrdup(cmdstr);
@@ -9105,7 +9112,7 @@ pub unsafe extern "C" fn sed_main(
   argv = argv.offset(optind as isize);
   if opt & OPT_in_place as libc::c_int as libc::c_uint != 0 {
     // -i
-    die_func = Some(cleanup_outname as unsafe extern "C" fn() -> ())
+    die_func = Some(cleanup_outname)
   } // -r or -E
   if opt & (2i32 | 4i32) as libc::c_uint != 0 {
     (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).regex_type |= 1i32


### PR DESCRIPTION
The shape on sed looked pretty bad so I took a stab at improving things a bit.
I tested using the [busybox tests](https://git.busybox.net/busybox/tree/testsuite/sed.tests) (with `SKIP_KNOWN_BUGS=true`).

The line count is down from 9284 to 1916 but there's still a bit of weird logic from switch/case statements hanging around. I'll take another look to see if I can get it down to around the same size as sed.c (1639 lines) but I thought it'd be good to post a PR in case anyone else started in this area.