### PR TITLE
Cleanup write and fwrite imports

### DIFF
--- a/console_tools/dumpkmap.rs
+++ b/console_tools/dumpkmap.rs
@@ -1,10 +1,5 @@
-use crate::librb::size_t;
 use libc;
-use libc::ssize_t;
 extern "C" {
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-
   #[no_mangle]
   fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
 
@@ -74,10 +69,10 @@ pub unsafe extern "C" fn dumpkmap_main(
       as *const libc::c_char as *const libc::c_void,
     ::std::mem::size_of::<[libc::c_char; 21]>() as libc::c_ulong,
   );
-  write(
+  libc::write(
     1i32,
     bb_common_bufsiz1.as_mut_ptr() as *const libc::c_void,
-    (7i32 + 256i32) as size_t,
+    7 + 256,
   );
   i = 0;
   while i < 13i32 {
@@ -95,10 +90,10 @@ pub unsafe extern "C" fn dumpkmap_main(
           i,
         ) == 0
         {
-          write(
-            1i32,
+          libc::write(
+            1,
             &mut ke.kb_value as *mut libc::c_ushort as *const libc::c_void,
-            2i32 as size_t,
+            2,
           );
         }
         j += 1

--- a/coreutils/fold.rs
+++ b/coreutils/fold.rs
@@ -12,8 +12,6 @@ extern "C" {
   fn getc_unlocked(__stream: *mut FILE) -> libc::c_int;
 
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-  #[no_mangle]
   fn memmove(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
 
   #[no_mangle]
@@ -59,7 +57,7 @@ unsafe extern "C" fn adjust_column(mut column: libc::c_uint, mut c: libc::c_char
 }
 /* Note that this function can write NULs, unlike fputs etc. */
 unsafe extern "C" fn write2stdout(mut buf: *const libc::c_void, mut size: libc::c_uint) {
-  fwrite(buf, 1i32 as size_t, size as size_t, stdout);
+  libc::fwrite(buf, 1, size as usize, stdout);
 }
 #[no_mangle]
 pub unsafe extern "C" fn fold_main(

--- a/coreutils/tee.rs
+++ b/coreutils/tee.rs
@@ -15,8 +15,6 @@ extern "C" {
   #[no_mangle]
   fn setbuf(__stream: *mut FILE, __buf: *mut libc::c_char);
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-  #[no_mangle]
   static bb_msg_standard_input: [libc::c_char; 0];
 
   #[no_mangle]
@@ -149,10 +147,10 @@ pub unsafe extern "C" fn tee_main(
     }
     fp = files;
     loop {
-      fwrite(
+      libc::fwrite(
         bb_common_bufsiz1.as_mut_ptr() as *const libc::c_void,
-        1i32 as size_t,
-        c as size_t,
+        1,
+        c as usize,
         *fp,
       );
       fp = fp.offset(1);

--- a/coreutils/uudecode.rs
+++ b/coreutils/uudecode.rs
@@ -12,8 +12,6 @@ extern "C" {
   #[no_mangle]
   fn fflush(__stream: *mut FILE) -> libc::c_int;
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-  #[no_mangle]
   fn fileno_unlocked(__stream: *mut FILE) -> libc::c_int;
 
   /* Guaranteed to NOT be a macro (smallest code). Saves nearly 2k on uclibc.
@@ -165,10 +163,10 @@ unsafe extern "C" fn read_stduu(
           break;
         }
       }
-      fwrite(
+      libc::fwrite(
         line as *const libc::c_void,
-        1i32 as size_t,
-        dst.wrapping_offset_from(line) as libc::c_long as size_t,
+        1,
+        dst.wrapping_offset_from(line) as usize,
         dst_stream,
       );
       free(line as *mut libc::c_void);

--- a/editors/ed.rs
+++ b/editors/ed.rs
@@ -9,7 +9,6 @@ use libc::mode_t;
 use libc::open;
 use libc::printf;
 use libc::puts;
-use libc::ssize_t;
 use libc::strchr;
 use libc::strcpy;
 use libc::FILE;
@@ -26,9 +25,6 @@ extern "C" {
 
   #[no_mangle]
   fn fputs_unlocked(__s: *const libc::c_char, __stream: *mut FILE) -> libc::c_int;
-
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
   #[no_mangle]
   fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -624,10 +620,10 @@ unsafe extern "C" fn printLines(
   }
   while num1 <= num2 {
     if expandFlag == 0 {
-      write(
-        1i32,
+      libc::write(
+        1,
         (*lp).data.as_ptr() as *const libc::c_void,
-        (*lp).len as size_t,
+        (*lp).len as usize,
       );
       let fresh4 = num1;
       num1 = num1 + 1;

--- a/editors/vi.rs
+++ b/editors/vi.rs
@@ -78,8 +78,6 @@ extern "C" {
   ) -> libc::c_int;
 
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-  #[no_mangle]
   fn fputs_unlocked(__s: *const libc::c_char, __stream: *mut FILE) -> libc::c_int;
 
   #[no_mangle]
@@ -851,10 +849,10 @@ unsafe extern "C" fn refresh(mut full_screen: libc::c_int) {
       );
       place_cursor(li, cs);
       // write line out to terminal
-      fwrite(
+      libc::fwrite(
         &mut *sp.offset(cs as isize) as *mut libc::c_char as *const libc::c_void,
-        (ce - cs + 1i32) as size_t,
-        1i32 as size_t,
+        (ce - cs + 1) as usize,
+        1,
         stdout,
       );
     }

--- a/libbb/safe_write.rs
+++ b/libbb/safe_write.rs
@@ -2,11 +2,6 @@ use crate::libbb::ptr_to_globals::bb_errno;
 use crate::librb::size_t;
 use libc;
 use libc::ssize_t;
-extern "C" {
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-
-}
 
 /*
  * Busybox main internal header file
@@ -265,7 +260,7 @@ pub unsafe extern "C" fn safe_write(
 ) -> ssize_t {
   let mut n: ssize_t = 0;
   loop {
-    n = write(fd, buf, count);
+    n = libc::write(fd, buf, count as usize);
     if n >= 0 || *bb_errno != 4i32 {
       break;
     }

--- a/libbb/uuencode.rs
+++ b/libbb/uuencode.rs
@@ -7,8 +7,6 @@ extern "C" {
   #[no_mangle]
   fn getc_unlocked(__stream: *mut FILE) -> libc::c_int;
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-  #[no_mangle]
   fn memmove(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
 
   #[no_mangle]
@@ -918,10 +916,10 @@ pub unsafe extern "C" fn read_base64(
     }
     out_tail = out_buf.as_mut_ptr();
     in_tail = decode_base64(&mut out_tail, in_buf.as_mut_ptr());
-    fwrite(
+    libc::fwrite(
       out_buf.as_mut_ptr() as *const libc::c_void,
-      out_tail.wrapping_offset_from(out_buf.as_mut_ptr()) as libc::c_long as size_t,
-      1i32 as size_t,
+      out_tail.wrapping_offset_from(out_buf.as_mut_ptr()) as usize,
+      1,
       dst_stream,
     );
     if term_seen != 0 {

--- a/libbb/xfuncs.rs
+++ b/libbb/xfuncs.rs
@@ -18,9 +18,6 @@ extern "C" {
   fn fcntl(__fd: libc::c_int, __cmd: libc::c_int, _: ...) -> libc::c_int;
 
   #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-
-  #[no_mangle]
   fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
   #[no_mangle]
   fn strncpy(_: *mut libc::c_char, _: *const libc::c_char, _: libc::c_ulong) -> *mut libc::c_char;
@@ -364,11 +361,7 @@ pub unsafe extern "C" fn hex2bin(
 /* Return how long the file at fd is, if there's any way to determine it. */
 #[no_mangle]
 pub unsafe extern "C" fn bb_putchar_stderr(mut ch: libc::c_char) -> libc::c_int {
-  return write(
-    2i32,
-    &mut ch as *mut libc::c_char as *const libc::c_void,
-    1i32 as size_t,
-  ) as libc::c_int;
+  return libc::write(2, &mut ch as *mut libc::c_char as *const libc::c_void, 1) as libc::c_int;
 }
 
 #[no_mangle]

--- a/mailutils/mail.rs
+++ b/mailutils/mail.rs
@@ -21,9 +21,6 @@ extern "C" {
   fn fread(__ptr: *mut libc::c_void, __size: size_t, __n: size_t, __stream: *mut FILE) -> size_t;
 
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-
-  #[no_mangle]
   static ptr_to_globals: *mut globals;
 
   #[no_mangle]
@@ -228,14 +225,10 @@ unsafe extern "C" fn encode_n_base64(
       text = text.offset(size as isize);
       len = (len as libc::c_ulong).wrapping_sub(size) as size_t as size_t
     }
-    fwrite(
+    libc::fwrite(
       dst_buf.as_mut_ptr() as *const libc::c_void,
-      1i32 as size_t,
-      (4i32 as libc::c_ulong).wrapping_mul(
-        size
-          .wrapping_add(2i32 as libc::c_ulong)
-          .wrapping_div(3i32 as libc::c_ulong),
-      ),
+      1,
+      4 * ((size as usize + 2) / 3),
       stdout,
     );
   }

--- a/miscutils/microcom.rs
+++ b/miscutils/microcom.rs
@@ -21,8 +21,6 @@ extern "C" {
 
   #[no_mangle]
   fn dprintf(__fd: libc::c_int, __fmt: *const libc::c_char, _: ...) -> libc::c_int;
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
   #[no_mangle]
   fn poll(__fds: *mut pollfd, __nfds: nfds_t, __timeout: libc::c_int) -> libc::c_int;
@@ -275,11 +273,7 @@ pub unsafe extern "C" fn microcom_main(
                 match current_block {
                   13460095289871124136 => {}
                   _ => {
-                    write(
-                      sfd,
-                      &mut c as *mut libc::c_char as *const libc::c_void,
-                      1i32 as size_t,
-                    );
+                    libc::write(sfd, &mut c as *mut libc::c_char as *const libc::c_void, 1);
                     if delay >= 0 {
                       crate::libbb::safe_poll::safe_poll(pfd.as_mut_ptr(), 1i32 as nfds_t, delay);
                     }

--- a/miscutils/watchdog.rs
+++ b/miscutils/watchdog.rs
@@ -7,13 +7,9 @@ extern "C" {
   static mut optind: libc::c_int;
   #[no_mangle]
   fn usleep(__useconds: useconds_t) -> libc::c_int;
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
 }
 
-use crate::librb::size_t;
-use libc::ssize_t;
 use libc::useconds_t;
 pub type C2RustUnnamed = libc::c_uint;
 pub const BB_FATAL_SIGS: C2RustUnnamed = 117503054;
@@ -26,11 +22,7 @@ pub const DAEMON_DEVNULL_STDIO: C2RustUnnamed_0 = 2;
 pub const DAEMON_CHDIR_ROOT: C2RustUnnamed_0 = 1;
 unsafe extern "C" fn shutdown_watchdog() {
   static mut V: libc::c_char = 'V' as i32 as libc::c_char; /* Magic, see watchdog-api.txt in kernel */
-  write(
-    3i32,
-    &V as *const libc::c_char as *const libc::c_void,
-    1i32 as size_t,
-  );
+  libc::write(3, &V as *const libc::c_char as *const libc::c_void, 1);
   close(3i32);
 }
 unsafe extern "C" fn shutdown_on_signal(mut _sig: libc::c_int) {
@@ -145,10 +137,10 @@ pub unsafe extern "C" fn watchdog_main(
      * Make sure we clear the counter before sleeping,
      * as the counter value is undefined at this point -- PFM
      */
-    write(
-      3i32,
+    libc::write(
+      3,
       b"\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-      1i32 as size_t,
+      1,
     ); /* write zero byte */
     usleep((stimer_duration as libc::c_long * 1000i64) as useconds_t);
   }

--- a/networking/brctl.rs
+++ b/networking/brctl.rs
@@ -21,8 +21,6 @@ extern "C" {
 
   #[no_mangle]
   fn fputs_unlocked(__s: *const libc::c_char, __stream: *mut FILE) -> libc::c_int;
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
   #[no_mangle]
   fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> libc::c_int;
@@ -336,10 +334,10 @@ unsafe extern "C" fn write_uint(
     b"%u\n\x00" as *const u8 as *const libc::c_char,
     val,
   );
-  if write(
+  if libc::write(
     fd,
     bb_common_bufsiz1.as_mut_ptr() as *const libc::c_void,
-    n as size_t,
+    n as usize,
   ) < 0
   {
     crate::libbb::perror_msg::bb_simple_perror_msg_and_die(name);

--- a/networking/libiproute/iproute.rs
+++ b/networking/libiproute/iproute.rs
@@ -1,5 +1,4 @@
 use crate::libbb::appletlib::applet_name;
-use crate::librb::size_t;
 use crate::librb::smallint;
 use crate::librb::socklen_t;
 use libc;
@@ -7,13 +6,10 @@ use libc::close;
 use libc::fprintf;
 use libc::printf;
 use libc::sockaddr;
-use libc::ssize_t;
 use libc::strcmp;
 use libc::FILE;
 extern "C" {
 
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
   #[no_mangle]
   static mut stderr: *mut FILE;
 
@@ -1411,10 +1407,10 @@ unsafe extern "C" fn iproute_flush_cache() {
   if flush_fd < 0 {
     return;
   }
-  if write(
+  if libc::write(
     flush_fd,
     b"-1\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-    2i32 as size_t,
+    2,
   ) < 2
   {
     crate::libbb::perror_msg::bb_simple_perror_msg(

--- a/networking/libiproute/libnetlink.rs
+++ b/networking/libiproute/libnetlink.rs
@@ -27,10 +27,6 @@ extern "C" {
   fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
   #[no_mangle]
   fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-
 }
 
 #[repr(C)]
@@ -212,7 +208,7 @@ pub unsafe extern "C" fn rtnl_send_check(
   let mut h: *mut nlmsghdr = std::ptr::null_mut();
   let mut status: libc::c_int = 0;
   let mut resp: [libc::c_char; 1024] = [0; 1024];
-  status = write((*rth).fd, buf, len as size_t) as libc::c_int;
+  status = libc::write((*rth).fd, buf, len as usize) as libc::c_int;
   if status < 0 {
     return status;
   }

--- a/networking/nc.rs
+++ b/networking/nc.rs
@@ -59,8 +59,6 @@ extern "C" {
   static mut stderr: *mut FILE;
 
   #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-  #[no_mangle]
   fn read(__fd: libc::c_int, __buf: *mut libc::c_void, __nbytes: size_t) -> ssize_t;
 
   #[no_mangle]
@@ -714,10 +712,10 @@ trick for getting the RTT.  [I got that idea from pluvius, and warped it.]
 Return either the original fd, or clean up and return -1. */
 unsafe extern "C" fn udptest() -> libc::c_int {
   let mut rr: libc::c_int = 0; // can be interrupted! while (t) nanosleep(&t)?
-  rr = write(
+  rr = libc::write(
     netfd as libc::c_int,
     (*ptr_to_globals).bigbuf_in.as_mut_ptr() as *const libc::c_void,
-    1i32 as size_t,
+    1,
   ) as libc::c_int;
   if rr != 1i32 {
     crate::libbb::perror_msg::bb_simple_perror_msg(
@@ -762,10 +760,10 @@ unsafe extern "C" fn udptest() -> libc::c_int {
     close(rr);
     (*ptr_to_globals).o_wait = 0 as libc::c_uint
   }
-  rr = write(
+  rr = libc::write(
     netfd as libc::c_int,
     (*ptr_to_globals).bigbuf_in.as_mut_ptr() as *const libc::c_void,
-    1i32 as size_t,
+    1,
   ) as libc::c_int;
   return (rr != 1i32) as libc::c_int;
   /* don't need to restore themaddr's port, it's not used anymore */
@@ -1000,7 +998,7 @@ unsafe extern "C" fn readwrite() -> libc::c_int {
     not sure if the order of this matters, but write net -> stdout first. */
     {
       if rnleft != 0 {
-        rr = write(1i32, np as *const libc::c_void, rnleft as size_t) as libc::c_int;
+        rr = libc::write(1, np as *const libc::c_void, rnleft as usize) as libc::c_int;
         if rr > 0 {
           if option_mask32 & OPT_o as libc::c_int as libc::c_uint != 0 {
             /* log the stdout */
@@ -1021,11 +1019,8 @@ unsafe extern "C" fn readwrite() -> libc::c_int {
         } else {
           rr = rzleft as libc::c_int
         } /* one line, or the whole buffer */
-        rr = write(
-          netfd as libc::c_int,
-          zp as *const libc::c_void,
-          rr as size_t,
-        ) as libc::c_int;
+        rr =
+          libc::write(netfd as libc::c_int, zp as *const libc::c_void, rr as usize) as libc::c_int;
         if rr > 0 {
           if option_mask32 & OPT_o as libc::c_int as libc::c_uint != 0 {
             /* log what got sent */

--- a/networking/nslookup.rs
+++ b/networking/nslookup.rs
@@ -112,8 +112,6 @@ extern "C" {
 
   #[no_mangle]
   fn read(__fd: libc::c_int, __buf: *mut libc::c_void, __nbytes: size_t) -> ssize_t;
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
   /* { "-", NULL } */
   #[no_mangle]
   static mut option_mask32: u32;
@@ -833,7 +831,7 @@ unsafe extern "C" fn send_queries(mut ns: *mut ns) -> libc::c_int {
       .qlen
         == 0 as libc::c_uint)
       {
-        if write(
+        if libc::write(
           pfd.fd,
           (*(*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
             .query
@@ -843,7 +841,7 @@ unsafe extern "C" fn send_queries(mut ns: *mut ns) -> libc::c_int {
           (*(*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
             .query
             .offset(qn as isize))
-          .qlen as size_t,
+          .qlen as usize,
         ) < 0
         {
           crate::libbb::perror_msg::bb_perror_msg(
@@ -944,7 +942,7 @@ unsafe extern "C" fn send_queries(mut ns: *mut ns) -> libc::c_int {
                     //UNUSED: ns->failures++;
                     if servfail_retry != 0 {
                       servfail_retry -= 1;
-                      write(
+                      libc::write(
                         pfd.fd,
                         (*(*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
                           .query
@@ -954,7 +952,7 @@ unsafe extern "C" fn send_queries(mut ns: *mut ns) -> libc::c_int {
                         (*(*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
                           .query
                           .offset(qn as isize))
-                        .qlen as size_t,
+                        .qlen as usize,
                       );
                       current_block = 6236198777448170658;
                     } else {

--- a/networking/pscan.rs
+++ b/networking/pscan.rs
@@ -1,6 +1,5 @@
 use crate::libbb::ptr_to_globals::bb_errno;
 use crate::librb::len_and_sockaddr;
-use crate::librb::size_t;
 use crate::librb::socklen_t;
 use c2rust_asm_casts;
 use c2rust_asm_casts::AsmCastTrait;
@@ -10,7 +9,6 @@ use libc::printf;
 use libc::sockaddr;
 use libc::sockaddr_in;
 use libc::sockaddr_in6;
-use libc::ssize_t;
 use libc::useconds_t;
 extern "C" {
   pub type sockaddr_x25;
@@ -32,9 +30,6 @@ extern "C" {
   fn connect(__fd: libc::c_int, __addr: __CONST_SOCKADDR_ARG, __len: socklen_t) -> libc::c_int;
   #[no_mangle]
   fn getservbyport(__port: libc::c_int, __proto: *const libc::c_char) -> *mut servent;
-
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
 /* Version which dies on error */
 
@@ -300,10 +295,10 @@ pub unsafe extern "C" fn pscan_main(
         /* Unlikely, for me even localhost fails :) */
         {
           diff = (crate::libbb::time::monotonic_us() as libc::c_uint).wrapping_sub(start);
-          if !(write(
+          if !(libc::write(
             s,
             b" \x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-            1i32 as size_t,
+            1,
           ) >= 0)
           {
             current_block_42 = 17281240262373992796;

--- a/networking/udhcp/signalpipe.rs
+++ b/networking/udhcp/signalpipe.rs
@@ -1,25 +1,13 @@
 use crate::libbb::ptr_to_globals::bb_errno;
 
-use libc;
-extern "C" {
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-
-}
-
 use crate::librb::fd_pair;
 use crate::librb::size_t;
+use libc;
 use libc::pollfd;
-use libc::ssize_t;
 unsafe extern "C" fn signal_handler(mut sig: libc::c_int) {
   let mut sv: libc::c_int = *bb_errno; /* use char, avoid dealing with partial writes */
   let mut ch: libc::c_uchar = sig as libc::c_uchar;
-  if write(
-    4i32,
-    &mut ch as *mut libc::c_uchar as *const libc::c_void,
-    1i32 as size_t,
-  ) != 1
-  {
+  if libc::write(4, &mut ch as *mut libc::c_uchar as *const libc::c_void, 1) != 1 {
     crate::libbb::perror_msg::bb_simple_perror_msg(
       b"can\'t send signal\x00" as *const u8 as *const libc::c_char,
     );

--- a/printutils/lpr.rs
+++ b/printutils/lpr.rs
@@ -19,8 +19,6 @@ extern "C" {
   static mut optind: libc::c_int;
   #[no_mangle]
   fn dprintf(__fd: libc::c_int, __fmt: *const libc::c_char, _: ...) -> libc::c_int;
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
   #[no_mangle]
   fn strlen(__s: *const libc::c_char) -> size_t;
@@ -391,10 +389,10 @@ pub unsafe extern "C" fn lpqr_main(
           b"local file changed size?!\x00" as *const u8 as *const libc::c_char,
         ); // send ACK
       }
-      write(
+      libc::write(
         fd,
         b"\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-        1i32 as size_t,
+        1,
       );
       get_response_or_say_and_die(
         fd,

--- a/runit/runsv.rs
+++ b/runit/runsv.rs
@@ -329,7 +329,7 @@ unsafe extern "C" fn update_status(mut s: *mut svdir) {
   sz = libc::write(
     fd,
     &mut status as *mut svstatus_t as *const libc::c_void,
-    ::std::mem::size_of::<svstatus_t>() as usize,
+    ::std::mem::size_of::<svstatus_t>(),
   );
   close(fd);
   if sz as libc::c_ulong != ::std::mem::size_of::<svstatus_t>() as libc::c_ulong {

--- a/runit/runsv.rs
+++ b/runit/runsv.rs
@@ -39,8 +39,6 @@ extern "C" {
   fn fchdir(__fd: libc::c_int) -> libc::c_int;
 
   #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-  #[no_mangle]
   fn read(__fd: libc::c_int, __buf: *mut libc::c_void, __nbytes: size_t) -> ssize_t;
 
   #[no_mangle]
@@ -145,22 +143,22 @@ unsafe extern "C" fn warn_cannot(mut m: *const libc::c_char) {
   warn2_cannot(m, b"\x00" as *const u8 as *const libc::c_char);
 }
 unsafe extern "C" fn s_child(mut _sig_no: libc::c_int) {
-  write(
+  libc::write(
     (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
       .selfpipe
       .wr,
     b"\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-    1i32 as size_t,
+    1,
   );
 }
 unsafe extern "C" fn s_term(mut _sig_no: libc::c_int) {
   (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals)).sigterm = 1i32 as smallint;
-  write(
+  libc::write(
     (*(bb_common_bufsiz1.as_mut_ptr() as *mut globals))
       .selfpipe
       .wr,
     b"\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-    1i32 as size_t,
+    1,
   );
   /* XXX */
 }
@@ -220,7 +218,7 @@ unsafe extern "C" fn update_status(mut s: *mut svdir) {
         b"%u\n\x00" as *const u8 as *const libc::c_char,
         (*s).pid as libc::c_uint,
       );
-      write(fd, spid.as_mut_ptr() as *const libc::c_void, size as size_t);
+      libc::write(fd, spid.as_mut_ptr() as *const libc::c_void, size as usize);
     }
     close(fd);
     if crate::libbb::xfuncs_printf::rename_or_warn(fpidnew, fpid) != 0 {
@@ -257,10 +255,10 @@ unsafe extern "C" fn update_status(mut s: *mut svdir) {
   let fresh0 = p;
   p = p.offset(1);
   *fresh0 = '\n' as i32 as libc::c_char;
-  write(
+  libc::write(
     fd,
     stat_buf.as_mut_ptr() as *const libc::c_void,
-    p.wrapping_offset_from(stat_buf.as_mut_ptr()) as libc::c_long as size_t,
+    p.wrapping_offset_from(stat_buf.as_mut_ptr()) as usize,
   );
   close(fd);
   crate::libbb::xfuncs_printf::rename_or_warn(fstatnew, f_stat);
@@ -328,10 +326,10 @@ unsafe extern "C" fn update_status(mut s: *mut svdir) {
   if fd < 0 {
     return;
   }
-  sz = write(
+  sz = libc::write(
     fd,
     &mut status as *mut svstatus_t as *const libc::c_void,
-    ::std::mem::size_of::<svstatus_t>() as libc::c_ulong,
+    ::std::mem::size_of::<svstatus_t>() as usize,
   );
   close(fd);
   if sz as libc::c_ulong != ::std::mem::size_of::<svstatus_t>() as libc::c_ulong {

--- a/runit/sv.rs
+++ b/runit/sv.rs
@@ -28,8 +28,6 @@ extern "C" {
   #[no_mangle]
   fn usleep(__useconds: useconds_t) -> libc::c_int;
   #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-  #[no_mangle]
   fn read(__fd: libc::c_int, __buf: *mut libc::c_void, __nbytes: size_t) -> ssize_t;
 
   #[no_mangle]
@@ -543,7 +541,7 @@ unsafe extern "C" fn control(mut a: *const libc::c_char) -> libc::c_int {
     return -1i32;
   }
   l = strlen(a) as libc::c_int;
-  r = write(fd, a as *const libc::c_void, l as size_t) as libc::c_int;
+  r = libc::write(fd, a as *const libc::c_void, l as usize) as libc::c_int;
   close(fd);
   if r != l {
     warn(b"can\'t write to supervise/control\x00" as *const u8 as *const libc::c_char);

--- a/runit/svlogd.rs
+++ b/runit/svlogd.rs
@@ -60,8 +60,6 @@ extern "C" {
   #[no_mangle]
   fn asprintf(__ptr: *mut *mut libc::c_char, __fmt: *const libc::c_char, _: ...) -> libc::c_int;
   #[no_mangle]
-  fn fwrite(__ptr: *const libc::c_void, __size: size_t, __n: size_t, __s: *mut FILE) -> size_t;
-  #[no_mangle]
   static mut optind: libc::c_int;
 
   #[no_mangle]
@@ -821,12 +819,7 @@ unsafe extern "C" fn buffer_pwrite(
   loop {
     // //i = full_write(ld->fdcur, s, len);
     // //if (i != -1) break;
-    i = fwrite(
-      s as *const libc::c_void,
-      1i32 as size_t,
-      len as size_t,
-      (*ld).filecur,
-    ) as libc::c_int; /* impossible */
+    i = libc::fwrite(s as *const libc::c_void, 1, len as usize, (*ld).filecur) as libc::c_int; /* impossible */
     if i as libc::c_uint == len {
       break;
     }
@@ -1737,10 +1730,10 @@ pub unsafe extern "C" fn svlogd_main(
               if (*ld).matcherr as libc::c_int == 'e' as i32 {
                 /* runit-1.8.0 compat: if timestamping, do it on stderr too */
                 // //full_write(STDERR_FILENO, printptr, printlen);
-                fwrite(
+                libc::fwrite(
                   printptr as *const libc::c_void,
-                  1i32 as size_t,
-                  printlen as size_t,
+                  1,
+                  printlen as usize,
                   stderr,
                 );
               }
@@ -1788,10 +1781,10 @@ pub unsafe extern "C" fn svlogd_main(
                 if (*(*ptr_to_globals).dir.offset(i as isize)).matcherr as libc::c_int == 'e' as i32
                 {
                   // //full_write(STDERR_FILENO, lineptr, linelen);
-                  fwrite(
+                  libc::fwrite(
                     lineptr as *const libc::c_void,
-                    1i32 as size_t,
-                    (*ptr_to_globals).linelen as size_t,
+                    1,
+                    (*ptr_to_globals).linelen as usize,
                     stderr,
                   );
                 }

--- a/shell/ash.rs
+++ b/shell/ash.rs
@@ -61,8 +61,6 @@ extern "C" {
   fn uname(__name: *mut utsname) -> libc::c_int;
 
   #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
-  #[no_mangle]
   fn pipe(__pipedes: *mut libc::c_int) -> libc::c_int;
 
   #[no_mangle]
@@ -10316,10 +10314,10 @@ unsafe extern "C" fn preadfd() -> libc::c_int {
       );
       if nr == 0 {
         /* ^C pressed, "convert" to SIGINT */
-        write(
-          1i32,
+        libc::write(
+          1,
           b"^C\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-          2i32 as size_t,
+          2,
         );
         if !(*ash_ptr_to_globals_misc).trap[2].is_null() {
           *buf.offset(0) = '\n' as i32 as libc::c_char;

--- a/shell/hush.rs
+++ b/shell/hush.rs
@@ -30,7 +30,6 @@ use libc::sigprocmask;
 use libc::sigset_t;
 use libc::sprintf;
 use libc::sscanf;
-use libc::ssize_t;
 use libc::stat;
 use libc::strchr;
 use libc::strcmp;
@@ -63,9 +62,6 @@ extern "C" {
   fn times(__buffer: *mut tms) -> clock_t;
   #[no_mangle]
   fn uname(__name: *mut utsname) -> libc::c_int;
-
-  #[no_mangle]
-  fn write(__fd: libc::c_int, __buf: *const libc::c_void, __n: size_t) -> ssize_t;
 
   #[no_mangle]
   fn dup(__fd: libc::c_int) -> libc::c_int;
@@ -2331,10 +2327,10 @@ unsafe extern "C" fn get_user_input(mut i: *mut in_str) -> libc::c_int {
     }
     /* ^C or SIGINT: repeat */
     /* bash prints ^C even on real SIGINT (non-kbd generated) */
-    write(
-      1i32,
+    libc::write(
+      1,
       b"^C\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-      2i32 as size_t,
+      2,
     );
     (*ptr_to_globals).last_exitcode = (128i32 + 2i32) as smalluint
   }
@@ -8604,7 +8600,7 @@ unsafe extern "C" fn setup_heredoc(mut redir: *mut redir_struct) {
    * dynamically growing pipes. Must use non-blocking write! */
   crate::libbb::xfuncs::ndelay_on(pair.wr);
   loop {
-    written = write(pair.wr, heredoc as *const libc::c_void, len as size_t) as libc::c_int;
+    written = libc::write(pair.wr, heredoc as *const libc::c_void, len as usize) as libc::c_int;
     if written <= 0 {
       break;
     }


### PR DESCRIPTION
Most of the changes are quite simple, just changing to `libc::write` or converting arguments to `usize`.

I don't think there are any cases which require a signed integer is required or where an integer overflow is likely (where it wasn't in the original) but that might be something to keep an eye out for in this PR as there's a bunch of type conversion.

The change to `util_linux/fsck_minix.rs` was fairly big because c2rust seems to have exploded all the functions in that file (the [original](https://git.busybox.net/busybox/tree/util-linux/fsck_minix.c#n598) is only 11 lines long :/). Because it's a bigger change it would be good if a closer look was taken at it :)